### PR TITLE
Include the repository field

### DIFF
--- a/crates/msft/Cargo.toml
+++ b/crates/msft/Cargo.toml
@@ -6,6 +6,7 @@ keywords = ["Windows","SCM"]
 description = "Windows service API"
 edition = "2021"
 license = "MIT"
+repository = "https://github.com/TomzBench/msft"
 
 [dependencies]
 msft-service = "0.0.22"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.